### PR TITLE
fix tests that error under recent autoconfs

### DIFF
--- a/alienfile
+++ b/alienfile
@@ -108,6 +108,7 @@ share {
         {
           @lines = (
             ": \${AUTOM4TE=`alien_autoconf_root`'/bin/autom4te'}\n",
+	    ": \${trailer_m4=`alien_autoconf_root`'/share/autoconf/autoconf/trailer.m4'}\n",
             @lines
           );
           $exe->spew($shebang, @lines);

--- a/corpus/configure.ac
+++ b/corpus/configure.ac
@@ -1,1 +1,2 @@
 AC_INIT
+AC_OUTPUT


### PR DESCRIPTION
by inserting an additional envvar rewrite in alienfile and updating the sample
config.ac to end with AC_OUTPUT (autoconf borks now if not present)

PLICEASE, the latest version 0.16 of Alien::Autoconf borks as follows: A completed install works fine, but the tests fail, because an (evidently new since 0.16) envvar in autoconf needed rewriting so the tests could find it. Also, the latest autoconf then complains if your configure.ac doesn't have a AC_OUTPUT in it. 

So this patch does those things. I find if I run `dzil test` on current main, it fails, and on this PR, it passes.

Thanks for Alien-